### PR TITLE
[Technical Support] LPS-72761 Using bad portlet id in frontend-editor-alloyeditor-web module

### DIFF
--- a/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String portletId = portletDisplay.getRootPortletId();
+String portletId = portletDisplay.getId();
 
 boolean autoCreate = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-editor:autoCreate"));
 String contents = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-editor:contents"));


### PR DESCRIPTION
Hi Dustin,

Please keep in mind this fix depends on LPS-73343. As I wanted to write you yesterday if my fix would be correct I'm going to open more tickets with the same issue. I think in portal code where we use this pattern and the portlet is instancable we need to fix them.

Thanks,
 Zsaga